### PR TITLE
Bump CI Node from 18.18.0 to 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.18.0"
+          node-version: "20"
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Summary
- The post-merge GitHub Pages deploy is failing with `TypeError: (0 , U.tracingChannel) is not a function` ([failing run](https://github.com/rokucommunity/release-tracker/actions/runs/26597845498/job/78373424087)).
- Root cause: `vite-plugin-pwa` pulls in `workbox-build → glob → path-scurry → lru-cache`, and the current `lru-cache` calls `diagnostics_channel.tracingChannel`, which was only added in Node 19.9. CI is pinned to `18.18.0`, so the build crashes after the JS bundle is generated but before the service worker is emitted.
- Bumping `actions/setup-node` to `20` (current LTS) unblocks the build.

## Test plan
- [ ] Watch this PR's `build` workflow succeed and produce both `dist/sw.js` and the PWA precache manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)